### PR TITLE
Run apt-get update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ENV REVIEWDOG_VERSION=v0.12.0
 
 RUN apt-get update && apt-get -y install git
 
-RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
-    | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
+RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
 COPY lint.sh /lint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM cljkondo/clj-kondo
 
 ENV REVIEWDOG_VERSION=v0.12.0
 
-RUN apt-get -y install git
+RUN apt-get update && apt-get -y install git
 
-RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
+RUN curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
+    | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
 COPY lint.sh /lint.sh
 


### PR DESCRIPTION
In order to fix a problem while installing `git`, we should run an `apt-get update` before running an `apt-get install`.