### PR TITLE
Pin clj-kondo base image to 2026.01.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "chore"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cljkondo/clj-kondo
+FROM cljkondo/clj-kondo:2026.01.19
 
 ENV REVIEWDOG_VERSION=v0.12.0
 


### PR DESCRIPTION
Anonymous Docker Hub pulls of `:latest` tags hit rate limits in CI runners (HTTP 429). Pinning to a specific version avoids this.

Changes:
- `FROM cljkondo/clj-kondo` → `FROM cljkondo/clj-kondo:2026.01.19`