### PR TITLE
IT-2728 | Update docker image to pull from CICD ECR repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.2 - 2026-04-14
+
+- Use ECR pull-through cache for clj-kondo base image to avoid Docker Hub rate limits
+
 ## v1.0.1 - 2023-10-05
 
 - Update README

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cljkondo/clj-kondo:2026.01.19
+FROM 941333304678.dkr.ecr.us-east-1.amazonaws.com/docker-hub/cljkondo/clj-kondo:2026.01.19
 
 ENV REVIEWDOG_VERSION=v0.12.0
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ jobs:
     name: runner / clj-kondo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - name: clj-kondo
-        uses: splashfinancial/clojure-lint-action@TODO
+        uses: splashfinancial/clojure-lint-action@v1.0.2
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review # Change reporter.


### PR DESCRIPTION
# Proposed Changes

- Additions: 
- Updates: Updated dockerfile `from` location to point to our CICD ECR repo so we dont run into rate-limiting issues when running this against PRs
- Deletions:

## Pre-merge Checklist

- [ ] Write + run tests
- [ ] Update CHANGELOG and increment version
- [ ] Update README and relevant documentation
